### PR TITLE
修复插件报错无法使用的问题，并增加链接支持

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,20 +1,70 @@
 // 运行在 Electron 主进程 下的插件入口
-
+const { shell, ipcMain } = require("electron");
 
 // 加载插件时触发
 function onLoad(plugin, liteloader) {
+    const plugin_path = liteloader.plugins.markdown_it.path.plugin;
+    const hljs = require(`${plugin_path}/src/lib/highlight.js`);
+    const mark = require(`${plugin_path}/src/lib/markdown-it.js`)({
+            html: false, // 在源码中启用 HTML 标签
+            xhtmlOut: true, // 使用 '/' 来闭合单标签 （比如 <br />）。
+            // 这个选项只对完全的 CommonMark 模式兼容。
+            breaks: false, // 转换段落里的 '\n' 到 <br>。
+            langPrefix: "language-", // 给围栏代码块的 CSS 语言前缀。对于额外的高亮代码非常有用。
+            linkify: true, // 将类似 URL 的文本自动转换为链接。
 
+            // 启用一些语言中立的替换 + 引号美化
+            typographer: false,
+
+            // 双 + 单引号替换对，当 typographer 启用时。
+            // 或者智能引号等，可以是 String 或 Array。
+            //
+            // 比方说，你可以支持 '«»„“' 给俄罗斯人使用， '„“‚‘'  给德国人使用。
+            // 还有 ['«\xA0', '\xA0»', '‹\xA0', '\xA0›'] 给法国人使用（包括 nbsp）。
+            quotes: "“”‘’",
+
+            // 高亮函数，会返回转义的HTML。
+            // 或 '' 如果源字符串未更改，则应在外部进行转义。
+            // 如果结果以 <pre ... 开头，内部包装器则会跳过。
+            highlight: function (str, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    try {
+                        return (
+                            '<pre class="hljs"><code>' +
+                            hljs.highlight(lang, str, true).value +
+                            "</code></pre>"
+                        );
+                    } catch (__) {}
+                }
+
+                return (
+                    '<pre class="hljs"><code>' +
+                    mark.utils.escapeHtml(str) +
+                    "</code></pre>"
+                );
+            }
+        }),
+        katex = require(`${plugin_path}/src/lib/markdown-it-katex.js`);
+
+    mark.use(katex);
+
+    ipcMain.handle("LiteLoader.markdown_it.render", (event, content) => {
+        return mark.render(content);
+    });
+
+    ipcMain.handle("LiteLoader.markdown_it.open_link", (event, content) => {
+        if (content.indexOf("http") != 0) {
+            content = "http://" + content;
+        }
+        return shell.openExternal(content);
+    });
 }
-
 
 // 创建窗口时触发
-function onBrowserWindowCreated(window, plugin) {
-
-}
-
+function onBrowserWindowCreated(window, plugin) {}
 
 // 这两个函数都是可选的
 module.exports = {
     onLoad,
     onBrowserWindowCreated
-}
+};

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,8 +1,10 @@
 // Electron 主进程 与 渲染进程 交互的桥梁
-const { contextBridge } = require("electron");
-
+const { contextBridge, ipcRenderer } = require("electron");
 
 // 在window对象下导出只读对象
-contextBridge.exposeInMainWorld("plugin_template", {
-
+contextBridge.exposeInMainWorld("markdown_it", {
+    render: (content) =>
+        ipcRenderer.invoke("LiteLoader.markdown_it.render", content),
+    open_link: (content) =>
+        ipcRenderer.invoke("LiteLoader.markdown_it.open_link", content)
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -43,7 +43,17 @@ function onLoad() {
     //TODO: 添加缓存
     loadCSSFromURL(`https://lib.baomitu.com/KaTeX/0.16.8/katex.css`);
 
-    setInterval(render, 10);
+    const observer = new MutationObserver((mutationsList) => {
+        for (let mutation of mutationsList) {
+            if (mutation.type === "childList") {
+                render();
+            }
+        }
+    });
+
+    const targetNode = document.body;
+    const config = { childList: true, subtree: true };
+    observer.observe(targetNode, config);
 }
 
 // 打开设置界面时触发

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,64 +1,41 @@
 // 运行在 Electron 渲染进程 下的页面脚本
-const plugin_path = LiteLoader.plugins.markdown_it.path.plugin;
-const hljs = require(`${plugin_path}/src/lib/highlight.js`);
-const mark = require(`${plugin_path}/src/lib/markdown-it.js`)({
-    html: false,        // 在源码中启用 HTML 标签
-    xhtmlOut: true,        // 使用 '/' 来闭合单标签 （比如 <br />）。
-    // 这个选项只对完全的 CommonMark 模式兼容。
-    breaks: false,        // 转换段落里的 '\n' 到 <br>。
-    langPrefix: 'language-',  // 给围栏代码块的 CSS 语言前缀。对于额外的高亮代码非常有用。
-    linkify: true,        // 将类似 URL 的文本自动转换为链接。
-
-    // 启用一些语言中立的替换 + 引号美化
-    typographer: false,
-
-    // 双 + 单引号替换对，当 typographer 启用时。
-    // 或者智能引号等，可以是 String 或 Array。
-    //
-    // 比方说，你可以支持 '«»„“' 给俄罗斯人使用， '„“‚‘'  给德国人使用。
-    // 还有 ['«\xA0', '\xA0»', '‹\xA0', '\xA0›'] 给法国人使用（包括 nbsp）。
-    quotes: '“”‘’',
-
-    // 高亮函数，会返回转义的HTML。
-    // 或 '' 如果源字符串未更改，则应在外部进行转义。
-    // 如果结果以 <pre ... 开头，内部包装器则会跳过。
-    highlight: function (str, lang) {
-        if (lang && hljs.getLanguage(lang)) {
-            try {
-                return '<pre class="hljs"><code>' +
-                    hljs.highlight(lang, str, true).value +
-                    '</code></pre>';
-            } catch (__) { }
-        }
-
-        return '<pre class="hljs"><code>' + mark.utils.escapeHtml(str) + '</code></pre>';
-    }
-}),
-    katex = require(`${plugin_path}/src/lib/markdown-it-katex.js`);
-
-mark.use(katex);
-
 
 // 使用 markdown-it 渲染每个span标记的内容
 function render() {
-    const elements = document.querySelectorAll('.message-content > span > span');
-    elements.forEach(element => {
-        const renderedHTML = mark.render(element.textContent);
-        const tempElement = document.createElement('div');
+    const elements = document.querySelectorAll(
+        ".message-content > span > span"
+    );
+    elements.forEach(async (element) => {
+        const renderedHTML = await markdown_it.render(element.textContent);
+        const tempElement = document.createElement("div");
         tempElement.innerHTML = renderedHTML;
         element.replaceWith(...tempElement.childNodes);
     });
+
+    setTimeout(() => {
+        var elements = document.querySelectorAll("a");
+        elements.forEach((e) => {
+            e.onclick = async (e) => {
+                e.preventDefault();
+                await markdown_it.open_link(
+                    e.path[0].href.replace("app://./renderer/", "")
+                );
+                return false;
+            };
+        });
+    }, 100);
 }
 
 function loadCSSFromURL(url) {
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
     link.href = url;
     document.head.appendChild(link);
 }
 
-
 function onLoad() {
+    const plugin_path = LiteLoader.plugins.markdown_it.path.plugin;
+
     loadCSSFromURL(`${plugin_path}/src/style/markdown.css`);
     loadCSSFromURL(`${plugin_path}/src/style/hljs-github-dark.css`);
 
@@ -69,15 +46,8 @@ function onLoad() {
     setInterval(render, 10);
 }
 
-
 // 打开设置界面时触发
-function onConfigView(view) {
-
-}
-
+function onConfigView(view) {}
 
 // 这两个函数都是可选的
-export {
-    onLoad,
-    onConfigView
-}
+export { onLoad, onConfigView };


### PR DESCRIPTION
- 修复插件报错require不存在的问题
- 修复点击链接却在QQ自身打开的问题（而不是用默认浏览器）

你应该在main里面使用require，而不是在renderer里（报错require未定义）。
现在是renderer.js通过IPC访问main里面markdown_it的render函数进行渲染，正常使用。
另外，链接需要额外处理一下，否则会在QQ界面里直接打开网页。