### PR TITLE
为链接添加一个默认的css，以方便其他主题插件修改链接的配色

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,9 +11,12 @@ function render() {
         tempElement.innerHTML = renderedHTML;
         var elements = tempElement.querySelectorAll("a");
         elements.forEach((e) => {
+            e.classList.add("markdown_it_link");
             e.onclick = async (event) => {
                 event.preventDefault();
-                const href = event.composedPath()[0].href.replace("app://./renderer/", "");
+                const href = event
+                    .composedPath()[0]
+                    .href.replace("app://./renderer/", "");
                 await markdown_it.open_link(href);
                 return false;
             };
@@ -50,7 +53,7 @@ function onLoad() {
 }
 
 // 打开设置界面时触发
-function onConfigView(view) { }
+function onConfigView(view) {}
 
 // 这两个函数都是可选的
 export { onLoad, onConfigView };


### PR DESCRIPTION
安装我的背景图插件后，夜间模式下链接默认是深蓝色，看不清。给链接添加上css类后，我就能在我的插件里为markdown里的链接单独设置颜色了。