### PR TITLE
fix: 修复某些自定义主题下正常对话气泡中的聊天文本颜色错误

### DIFF
--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -1,3 +1,7 @@
+.message-content {
+    color: var(--chatarea-text-color-self);
+}
+
 .message-content h1 {
     font-size: 2em;
     margin: 0.67em 0;


### PR DESCRIPTION
改的markdown.css