### PR TITLE
Add support for LiteLoaderQQNT 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (C) 2023 CJReinforce <chengjie2022@ia.ac.cn>
+ Copyright (C) 2023 d0j1a_1701 <dajia1701@gmail.com>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (C) 2023 d0j1a_1701 <dajia1701@gmail.com>
+ Copyright (C) 2023 CJReinforce <chengjie2022@ia.ac.cn>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,23 @@
 {
-    "manifest_version": 3,
+    "manifest_version": 4,
     "type": "extension",
     "name": "Markdown-it",
     "slug": "markdown_it",
-    "thumbnail": "./icon.png",
+    "icon": "./icon.png",
     "description": "为 QQNT 提供 Markdown 渲染",
-    "version": "0.3.1",
-    "author": [
+    "version": "1.0.0",
+    "authors": [
         {
             "name": "d0j1a_1701",
             "link": "https://github.com/d0j1a1701"
+        },
+        {
+            "name": "CJReinforce",
+            "link": "https://github.com/CJReinforce"
         }
     ],
     "repository": {
-        "repo": "d0j1a1701/LiteLoaderQQNT-Markdown",
+        "repo": "CJReinforce/LiteLoaderQQNT-Markdown",
         "branch": "v3"
     },
     "platform": [

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
     ],
     "repository": {
         "repo": "CJReinforce/LiteLoaderQQNT-Markdown",
-        "branch": "v3"
+        "branch": "v4"
     },
     "platform": [
         "win32",

--- a/src/lib/markdown-it-katex.js
+++ b/src/lib/markdown-it-katex.js
@@ -548,7 +548,7 @@ var SETTINGS_SCHEMA = {
   },
   output: {
     type: {
-      enum: ["htmlAndMathml", "html", "mathml"]
+      enum: ["mathml", "htmlAndMathml", "html"]
     },
     description: "Determines the markup language of the output.",
     cli: "-F, --format <type>"

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,11 @@
 // 运行在 Electron 主进程 下的插件入口
 const { shell, ipcMain } = require("electron");
 
+onLoad();
+
 // 加载插件时触发
-function onLoad(plugin) {
-    const plugin_path = plugin.path.plugin;
+function onLoad() {
+    const plugin_path = LiteLoader.plugins["markdown_it"].path.plugin;
     const hljs = require(`${plugin_path}/src/lib/highlight.js`);
     const katex = require(`${plugin_path}/src/lib/markdown-it-katex.js`);
     const pangu = require(`${plugin_path}/src/lib/markdown-it-pangu.js`)
@@ -11,7 +13,7 @@ function onLoad(plugin) {
         html: false, // 在源码中启用 HTML 标签
         xhtmlOut: true, // 使用 '/' 来闭合单标签 （比如 <br />）。
         // 这个选项只对完全的 CommonMark 模式兼容。
-        breaks: false, // 转换段落里的 '\n' 到 <br>。
+        breaks: true, // 转换段落里的 '\n' 到 <br>。
         langPrefix: "language-", // 给围栏代码块的 CSS 语言前缀。对于额外的高亮代码非常有用。
         linkify: true, // 将类似 URL 的文本自动转换为链接。
 
@@ -49,6 +51,7 @@ function onLoad(plugin) {
         .use(katex)
         .use(pangu);
     ipcMain.handle("LiteLoader.markdown_it.render", (event, content) => {
+        // console.log(`[Markdown-It] Rendering content: \n${mark.render(content)}`);
         return mark.render(content);
     });
     ipcMain.handle("LiteLoader.markdown_it.open_link", (event, content) => {
@@ -61,5 +64,5 @@ function onLoad(plugin) {
 
 // 这两个函数都是可选的
 module.exports = {
-    onLoad
+    // onLoad
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -41,12 +41,14 @@ function loadCSSFromURL(url) {
     document.head.appendChild(link);
 }
 
+onLoad();
+
 function onLoad() {
     const plugin_path = LiteLoader.plugins.markdown_it.path.plugin;
 
-    loadCSSFromURL(`llqqnt://local-file/${plugin_path}/src/style/markdown.css`);
-    loadCSSFromURL(`llqqnt://local-file/${plugin_path}/src/style/hljs-github.css`);
-    loadCSSFromURL(`llqqnt://local-file/${plugin_path}/src/style/katex.css`);
+    loadCSSFromURL(`local:///${plugin_path}/src/style/markdown.css`);
+    loadCSSFromURL(`local:///${plugin_path}/src/style/hljs-github-dark.css`);
+    loadCSSFromURL(`local:///${plugin_path}/src/style/katex.css`);
 
     const observer = new MutationObserver((mutationsList) => {
         for (let mutation of mutationsList) {
@@ -62,6 +64,6 @@ function onLoad() {
 }
 
 // 打开设置界面时触发
-function onConfigView(view) { }
+function onSettingWindowCreated(view) { }
 
-export { onLoad };
+// export { onLoad };

--- a/src/style/hljs-github.css
+++ b/src/style/hljs-github.css
@@ -1,113 +1,3 @@
-@media (prefers-color-scheme: light) {
-    .hljs {
-        display: block;
-        overflow-x: auto;
-        padding: 0.5em;
-
-        color: #24292e;
-        background: #ffffff;
-    }
-
-    .hljs-comment,
-    .hljs-punctuation {
-        color: #6a737d;
-    }
-
-    .hljs-attr,
-    .hljs-attribute,
-    .hljs-meta,
-    .hljs-selector-attr,
-    .hljs-selector-class,
-    .hljs-selector-id {
-        color: #005cc5;
-    }
-
-    .hljs-variable,
-    .hljs-literal,
-    .hljs-number,
-    .hljs-doctag {
-        color: #e36209;
-    }
-
-    .hljs-params {
-        color: #24292e;
-    }
-
-    .hljs-function {
-        color: #6f42c1;
-    }
-
-    .hljs-class,
-    .hljs-tag,
-    .hljs-title,
-    .hljs-built_in {
-        color: #22863a;
-    }
-
-    .hljs-keyword,
-    .hljs-type,
-    .hljs-builtin-name,
-    .hljs-meta-keyword,
-    .hljs-template-tag,
-    .hljs-template-variable {
-        color: #d73a49;
-    }
-
-    .hljs-string,
-    .hljs-undefined {
-        color: #032f62;
-    }
-
-    .hljs-regexp {
-        color: #032f62;
-    }
-
-    .hljs-symbol {
-        color: #005cc5;
-    }
-
-    .hljs-bullet {
-        color: #e36209;
-    }
-
-    .hljs-section {
-        color: #005cc5;
-        font-weight: bold;
-    }
-
-    .hljs-quote,
-    .hljs-name,
-    .hljs-selector-tag,
-    .hljs-selector-pseudo {
-        color: #22863a;
-    }
-
-    .hljs-emphasis {
-        color: #e36209;
-        font-style: italic;
-    }
-
-    .hljs-strong {
-        color: #e36209;
-        font-weight: bold;
-    }
-
-    .hljs-deletion {
-        color: #b31d28;
-        background-color: #ffeef0;
-    }
-
-    .hljs-addition {
-        color: #22863a;
-        background-color: #f0fff4;
-    }
-
-    .hljs-link {
-        color: #032f62;
-        font-style: underline;
-    }
-}
-
 @media (prefers-color-scheme: dark) {
     .hljs {
         display: block;
@@ -214,6 +104,116 @@
 
     .hljs-link {
         color: #a5d6ff;
+        font-style: underline;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    .hljs {
+        display: block;
+        overflow-x: auto;
+        padding: 0.5em;
+
+        color: #24292e;
+        background: #ffffff;
+    }
+
+    .hljs-comment,
+    .hljs-punctuation {
+        color: #6a737d;
+    }
+
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-meta,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id {
+        color: #005cc5;
+    }
+
+    .hljs-variable,
+    .hljs-literal,
+    .hljs-number,
+    .hljs-doctag {
+        color: #e36209;
+    }
+
+    .hljs-params {
+        color: #24292e;
+    }
+
+    .hljs-function {
+        color: #6f42c1;
+    }
+
+    .hljs-class,
+    .hljs-tag,
+    .hljs-title,
+    .hljs-built_in {
+        color: #22863a;
+    }
+
+    .hljs-keyword,
+    .hljs-type,
+    .hljs-builtin-name,
+    .hljs-meta-keyword,
+    .hljs-template-tag,
+    .hljs-template-variable {
+        color: #d73a49;
+    }
+
+    .hljs-string,
+    .hljs-undefined {
+        color: #032f62;
+    }
+
+    .hljs-regexp {
+        color: #032f62;
+    }
+
+    .hljs-symbol {
+        color: #005cc5;
+    }
+
+    .hljs-bullet {
+        color: #e36209;
+    }
+
+    .hljs-section {
+        color: #005cc5;
+        font-weight: bold;
+    }
+
+    .hljs-quote,
+    .hljs-name,
+    .hljs-selector-tag,
+    .hljs-selector-pseudo {
+        color: #22863a;
+    }
+
+    .hljs-emphasis {
+        color: #e36209;
+        font-style: italic;
+    }
+
+    .hljs-strong {
+        color: #e36209;
+        font-weight: bold;
+    }
+
+    .hljs-deletion {
+        color: #b31d28;
+        background-color: #ffeef0;
+    }
+
+    .hljs-addition {
+        color: #22863a;
+        background-color: #f0fff4;
+    }
+
+    .hljs-link {
+        color: #032f62;
         font-style: underline;
     }
 }


### PR DESCRIPTION
Add support for LiteLoaderQQNT 1.0.0
添加了对LiteLoaderQQNT 1.0.0的支持

I have tested for basic Markdown gramma and formula (see Figure 1 and 2). But I found that `$\LaTeX$` seems not being rendered properly (Figure 3).
我测试了基础的markdown语法和公式，见图1和图2。但我发现`$\LaTeX$`没有被正常渲染，见图3。

![1](https://github.com/d0j1a1701/LiteLoaderQQNT-Markdown/assets/51627740/04c30e63-8dff-43b7-a159-5166ae079bf4)
![2](https://github.com/d0j1a1701/LiteLoaderQQNT-Markdown/assets/51627740/1ee1d124-be34-4385-a3b9-4f856fecfc38)
![3](https://github.com/d0j1a1701/LiteLoaderQQNT-Markdown/assets/51627740/d342b67c-cc2f-4440-984d-14b795a1aa39)

Due to a complete lack of knowledge in frontend basics/Node.js/Electron, etc., but urgently needing markdown rendering functionality, I modify codes with the help of GPT-4, and also by comparing the implementations of several other plugins. Therefore, the correctness of the code may need to be checked, and I can only ensure that the examples shown in the above figures are rendered correctly.
由于完全没有前端基础知识/Node.js/Electron等知识，但是迫切需要markdown渲染功能，我借助gpt4，以及比对了多个其他插件的写法进行修改，因此代码正确性可能需要检查，只能保证图中展示的例子能够正确渲染。