### PR TITLE
refactor(renderer): 重写 render 函数适配 QQ 消息

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ function onLoad() {
     const katex = require(`${plugin_path}/src/lib/markdown-it-katex.js`);
     const pangu = require(`${plugin_path}/src/lib/markdown-it-pangu.js`)
     const mark = require(`${plugin_path}/src/lib/markdown-it.js`)({
-        html: false, // 在源码中启用 HTML 标签
+        html: true, // 在源码中启用 HTML 标签
         xhtmlOut: true, // 使用 '/' 来闭合单标签 （比如 <br />）。
         // 这个选项只对完全的 CommonMark 模式兼容。
         breaks: true, // 转换段落里的 '\n' 到 <br>。

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,37 +1,97 @@
 // 运行在 Electron 渲染进程 下的页面脚本
 
-// 使用 markdown-it 渲染每个span标记的内容
+
+// 将所有 span 合并
+// 并使用 markdown-it 渲染
 function render() {
     const elements = document.querySelectorAll(
-        ".message-content > span > span"
+        ".message-content"
     );
-    elements.forEach(async (element) => {
-        // 特判 @
-        if (element.className.includes("text-element--at")) return;
-        // 将 QQ 默认生成的 link 合并到 上一个 span 中
-        if (element.nextElementSibling && element.nextElementSibling.className && element.nextElementSibling.className.includes("text-link")) {
-            element.textContent += element.nextElementSibling.textContent;
-            element.parentNode.removeChild(element.nextElementSibling);
-        }
-        const renderedHTML = await markdown_it.render(element.textContent);
-        const tempElement = document.createElement("div");
-        tempElement.classList.add('markdown-body');
-        tempElement.innerHTML = renderedHTML;
-        var elements = tempElement.querySelectorAll("a");
-        elements.forEach((e) => {
-            e.classList.add("markdown_it_link");
-            e.classList.add("text-link");
-            e.onclick = async (event) => {
-                event.preventDefault();
-                const href = event
-                    .composedPath()[0]
-                    .href.replace("app://./renderer/", "");
-                await markdown_it.open_link(href);
-                return false;
-            };
-        });
-        element.replaceWith(...tempElement.childNodes);
-    });
+
+    Array.from(elements)
+        // 跳过已渲染的消息
+        .filter((messageBox) => !messageBox.classList.contains('markdown-rendered'))
+        // 跳过空消息
+        .filter((messageBox) => messageBox.childNodes.length > 0)
+        .forEach(async (messageBox) => {
+            // 标记已渲染 markdown，防止重复执行导致性能损失
+            messageBox.classList.add('markdown-rendered')
+
+            // 消息都在 span 里
+            const spanElem = Array.from(messageBox.childNodes)
+                .filter((e) => e.tagName == 'SPAN')
+
+            if (spanElem.length == 0) return
+
+            // 坐标位置，以备后续将 html 元素插入文档中
+            const posBase = document.createElement('span')
+            spanElem[0].before(posBase)
+
+            // 移除旧元素
+            spanElem
+                .filter((e) => messageBox.hasChildNodes(e))
+                .forEach((e) => {
+                    messageBox.removeChild(e)
+                })
+
+            // 对于纯文本，应该拿出 innerHTML。这不会发生 XSS 注入，因为 QQ 自身已经进行了转义
+            // 对于表情，at 信息等消息，生成占位标签，并在结束后使用原元素进行替换（避免markdownit渲染内容）
+            const markPieces = spanElem.map((msgPiece, index) => {
+                if (msgPiece.className.includes("text-element") && !msgPiece.querySelector('.text-element--at')) {
+                    return {
+                        mark: Array.from(msgPiece.getElementsByTagName("span"))
+                            .map((e) => e.innerHTML)
+                            .reduce((acc, x) => acc + x, ""),
+                        replace: null
+                    }
+                } else {
+                    const id = "placeholder-" + index
+                    return {
+                        mark: `<span id="${id}"></span>`,
+                        replace: (parent) => {
+                            const oldNode = parent.querySelector(`#${id}`)
+                            oldNode.replaceWith(msgPiece)
+                        }
+                    }
+                }
+            })
+
+            // 渲染 markdown
+            const marks = markPieces.map((p) => p.mark).reduce((acc, p) => acc + p, "")
+            const renderedHtml = await markdown_it.render(marks)
+
+            // 将原有元素替换回内容
+            const markdownBody = document.createElement('div')
+            markdownBody.innerHTML = renderedHtml
+            markPieces.filter((p) => p.replace != null)
+                .forEach((p) => {
+                    p.replace(markdownBody)
+                })
+
+            // 在外部浏览器打开连接
+            markdownBody.querySelectorAll("a").forEach((e) => {
+                e.classList.add("markdown_it_link");
+                e.classList.add("text-link");
+                e.onclick = async (event) => {
+                    event.preventDefault();
+                    const href = event
+                        .composedPath()[0]
+                        .href.replace("app://./renderer/", "");
+                    await markdown_it.open_link(href);
+                    return false;
+                };
+            })
+
+            // 放回内容
+            Array.from(markdownBody.childNodes)
+                .map((node) => node)
+                .forEach((elem) => {
+                    posBase.before(elem)
+                })
+            messageBox.removeChild(posBase)
+
+        })
+
 }
 
 function loadCSSFromURL(url) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -27,13 +27,6 @@ function render() {
             const posBase = document.createElement('span')
             spanElem[0].before(posBase)
 
-            // 移除旧元素
-            spanElem
-                .filter((e) => messageBox.hasChildNodes(e))
-                .forEach((e) => {
-                    messageBox.removeChild(e)
-                })
-
             // 对于纯文本，应该拿出 innerHTML。这不会发生 XSS 注入，因为 QQ 自身已经进行了转义
             // 对于表情，at 信息等消息，生成占位标签，并在结束后使用原元素进行替换（避免markdownit渲染内容）
             const markPieces = spanElem.map((msgPiece, index) => {
@@ -60,6 +53,13 @@ function render() {
             const marks = markPieces.map((p) => p.mark).reduce((acc, p) => acc + p, "")
             const renderedHtml = await markdown_it.render(marks)
 
+            // 移除旧元素
+            spanElem
+                .filter((e) => messageBox.hasChildNodes(e))
+                .forEach((e) => {
+                    messageBox.removeChild(e)
+                })
+            
             // 将原有元素替换回内容
             const markdownBody = document.createElement('div')
             markdownBody.innerHTML = renderedHtml
@@ -84,7 +84,6 @@ function render() {
 
             // 放回内容
             Array.from(markdownBody.childNodes)
-                .map((node) => node)
                 .forEach((elem) => {
                     posBase.before(elem)
                 })


### PR DESCRIPTION
修复方式比较 dirty，不过并没有什么明显的运行问题，先测几天看看是否可行

~~也许有更好的解决方式也说不定呢~~

---

重写 render 函数为将所有 span 拼接后使用 markdownit渲染。对于 QQ
内部的消息会先使用占位标签填充，在渲染结束后替换回原内容。

通过一次渲染一条消息的所有内容，在解决了格式问题的同时还减少了 IPC
次数。

由于 QQ 本身会对消息进行转义，因此可以放心的将 QQ 的消息使用 innerHtml
获取后放到 markdownit 中渲染。

该提交同时解决了 #31 中的问题1。

fix #22, fix #25