### PR TITLE
feat: Add Fenced code and LaTeX copy button.

### DIFF
--- a/src/components/code_block.js
+++ b/src/components/code_block.js
@@ -77,3 +77,24 @@ export function addOnClickHandleForCopyButton(element) {
             }
         });
 }
+
+/**
+ * Find all Copy Button of Latex block and add hanlder to it.
+ * 
+ * @param {HTMLElement} element 
+ */
+export function addOnClickHandleForLatexBlock(element) {
+    var buttons = element.querySelectorAll('div.katex-block-rendered>button.copy_latex');
+
+
+    Array.from(buttons)
+        .forEach(function (copyButton) {
+            try {
+                // find tex annotation
+                var latexAnno = copyButton.parentElement.querySelector('annotation[encoding="application/x-tex"]').textContent;
+                copyButton.onclick = () => { navigator.clipboard.writeText(latexAnno) };
+            } catch (e) {
+                ;
+            }
+        });
+}

--- a/src/components/code_block.js
+++ b/src/components/code_block.js
@@ -32,9 +32,13 @@ export function HighLightedCodeBlock({ content, lang, markdownItIns }) {
         Finalcontent = hljs.highlight(contentPreprocess(content), { language: lang, ignoreIllegals: true }).value;
     } catch (e) {
         console.debug(`[Markdown-it] hljs error: ${e}`);
-     }
+    }
 
     return (<pre className='hljs hl-code-block'>
+        <button className='lang_copy'>
+            <p className='lang'>{lang}</p>
+            <p className='copy'>复制</p>
+        </button>
         <code dangerouslySetInnerHTML={{ __html: Finalcontent }}></code>
     </pre>);
 }
@@ -52,4 +56,24 @@ export function renderInlineCodeBlockString(tokens, idx, options, env, slf) {
     return '<code' + slf.renderAttrs(token) + '>' +
         token.content +
         '</code>';
+}
+
+/**
+ * Find all Copy Button and add click handler to it. Will directly mutate the received 
+ * HTML element.
+ * 
+ * @param {HTMLElement} element 
+ */
+export function addOnClickHandleForCopyButton(element) {
+    var buttons = element.querySelectorAll('pre.hl-code-block>button.lang_copy');
+    Array.from(buttons)
+        .forEach(function (copyButton) {
+            try {
+                // get content of this code block
+                var codeContent = copyButton.parentElement.querySelector('code').textContent;
+                copyButton.onclick = () => { navigator.clipboard.writeText(codeContent) };
+            } catch (e) {
+                ;
+            }
+        });
 }

--- a/src/components/setting_page.js
+++ b/src/components/setting_page.js
@@ -147,6 +147,7 @@ function TextAndCaptionBlock({ title, caption }) {
                 data-type='secondary'
                 style={{
                     // "text-wrap": "wrap",
+                    'margin-top': '3px',
                     "word-break": "break-word"
                 }}
             ><p style={{

--- a/src/lib/markdown-it-katex.js
+++ b/src/lib/markdown-it-katex.js
@@ -88,6 +88,8 @@ for rendering output.
 'use strict';
 
 var katex = require('katex');
+import React from 'react';
+import { renderToString } from 'react-dom/server';
 
 // Test if potential opening or closing delimieter
 // Assumes that there is a "$" at state.src[pos]
@@ -247,7 +249,7 @@ function unescapeHtml(unsafe) {
     .replace(/&#039;/g, "\'");
 }
 
-module.exports = function math_plugin(md, options) {
+export default function math_plugin(md, options) {
   // Default options
 
   options = options || {};
@@ -279,7 +281,8 @@ module.exports = function math_plugin(md, options) {
     latex = unescapeHtml(latex); // work with QQNT Markdown-it
     options.displayMode = true;
     try {
-      return `<p class="katex-block ${options.blockClass}">` + katex.renderToString(latex, options) + "</p>";
+      // return `<p class="katex-block katex_rendered ${options.blockClass}">` + katex.renderToString(latex, options) + "</p>";
+      return renderToString(<KatexBlockComponent latex={latex} options={options} />);
     }
     catch (error) {
       if (options.throwOnError) { console.log(error); }
@@ -300,3 +303,13 @@ module.exports = function math_plugin(md, options) {
   md.renderer.rules.math_inline = inlineRenderer;
   md.renderer.rules.math_block = blockRenderer;
 };
+
+
+function KatexBlockComponent({ latex, options }) {
+  return (
+    <div className='katex-block-rendered'>
+      <button className='copy_latex'>复制公式</button>
+      <p className='katex-block' dangerouslySetInnerHTML={{ __html: katex.renderToString(latex, options) }}></p>
+    </div>
+  );
+}

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -15,7 +15,8 @@ import { escapeHtml, purifyHtml, unescapeHtml } from '@/utils/htmlProc';
 import {
     HighLightedCodeBlock,
     addOnClickHandleForCopyButton,
-    renderInlineCodeBlockString
+    renderInlineCodeBlockString,
+    addOnClickHandleForLatexBlock
 } from './components/code_block';
 
 // States
@@ -154,6 +155,9 @@ function render() {
 
             // Handle click of Copy Code Button
             addOnClickHandleForCopyButton(markdownBody);
+
+            // Handle click of Copy Latex Button
+            addOnClickHandleForLatexBlock(markdownBody);
 
             // 在外部浏览器打开连接
             markdownBody.querySelectorAll("a").forEach((e) => {

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -12,7 +12,11 @@ import katex from '@/lib/markdown-it-katex';
 import { escapeHtml, purifyHtml, unescapeHtml } from '@/utils/htmlProc';
 
 // Components
-import { HighLightedCodeBlock, renderInlineCodeBlockString } from './components/code_block';
+import {
+    HighLightedCodeBlock,
+    addOnClickHandleForCopyButton,
+    renderInlineCodeBlockString
+} from './components/code_block';
 
 // States
 import { useSettingsStore } from '@/states/settings';
@@ -147,6 +151,9 @@ function render() {
                 .forEach((p) => {
                     p.replace(markdownBody)
                 })
+
+            // Handle click of Copy Code Button
+            addOnClickHandleForCopyButton(markdownBody);
 
             // 在外部浏览器打开连接
             markdownBody.querySelectorAll("a").forEach((e) => {

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -100,6 +100,58 @@ span>p>img {
     height: auto;
 }
 
+/* Border radius for fenced code block */
 pre.hl-code-block {
+    position: relative;
+    min-width: 5rem;
+    min-height: 2rem;
     border-radius: 5px;
+}
+
+/* language and copy button style */
+pre.hl-code-block>button.lang_copy {
+    position: absolute;
+    right: 2px;
+    top: 2px;
+    min-width: 4rem;
+    min-height: 1.5rem;
+    backdrop-filter: blur(8px);
+    border-radius: 4px;
+    border-width: 0px;
+    box-shadow: 3px 10px 15px -3px rgb(0 0 0 / 0.1), 2px 4px 6px -6px rgb(0 0 0 / 0.1);
+
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 20ms;
+}
+
+pre.hl-code-block>button.lang_copy:active {
+    transform: scale(0.85);
+}
+
+
+@media(prefers-color-scheme: light) {
+    pre.hl-code-block>button.lang_copy {
+        background-color: rgba(255, 255, 255, 0.5);
+        color: black;
+    }
+}
+
+@media(prefers-color-scheme: dark) {
+    pre.hl-code-block>button.lang_copy {
+        background-color: rgba(0, 0, 0, 0.5);
+        color: white;
+    }
+}
+
+pre.hl-code-block:not(:hover)>button.lang_copy {
+    display: none;
+}
+
+pre.hl-code-block>button.lang_copy:hover>p.lang {
+    display: none;
+}
+
+pre.hl-code-block>button.lang_copy:not(:hover)>p.copy {
+    display: none;
 }

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -101,7 +101,8 @@ span>p>img {
 }
 
 /* Border radius for fenced code block */
-pre.hl-code-block {
+pre.hl-code-block,
+div.katex-block-rendered {
     position: relative;
     min-width: 5rem;
     min-height: 2rem;
@@ -109,7 +110,9 @@ pre.hl-code-block {
 }
 
 /* language and copy button style */
-pre.hl-code-block>button.lang_copy {
+pre.hl-code-block>button.lang_copy,
+div.katex-block-rendered>button.copy_latex {
+    z-index: 10;
     position: absolute;
     right: 2px;
     top: 2px;
@@ -125,26 +128,32 @@ pre.hl-code-block>button.lang_copy {
     transition-duration: 20ms;
 }
 
-pre.hl-code-block>button.lang_copy:active {
+pre.hl-code-block>button.lang_copy:active,
+div.katex-block-rendered>button.copy_latex:active {
     transform: scale(0.85);
 }
 
 
 @media(prefers-color-scheme: light) {
-    pre.hl-code-block>button.lang_copy {
+
+    pre.hl-code-block>button.lang_copy,
+    div.katex-block-rendered>button.copy_latex {
         background-color: rgba(255, 255, 255, 0.5);
         color: black;
     }
 }
 
 @media(prefers-color-scheme: dark) {
-    pre.hl-code-block>button.lang_copy {
+
+    pre.hl-code-block>button.lang_copy,
+    div.katex-block-rendered>button.copy_latex {
         background-color: rgba(0, 0, 0, 0.5);
         color: white;
     }
 }
 
-pre.hl-code-block:not(:hover)>button.lang_copy {
+pre.hl-code-block:not(:hover)>button.lang_copy,
+div.katex-block-rendered:not(:hover)>button.copy_latex {
     display: none;
 }
 


### PR DESCRIPTION
# Feature:

- Add _Fenced Code Block_ copy button.
- Add _LaTeX Block_ copy button.

# Fix:

- Add some space between `title` and `description` text inside Plugin Settings UI.
- Fix the issue that the font color is incorrect when using with _QQNT Telegram Theme_. (#26, #51)
- Add `try-catch` block to ensure `onLoad()` method will never throw error which may break _QQNT_ / _QQNT LiteLoader_.