### PR TITLE
fix: Change msgbox flex direction based on offsetHeight

### DIFF
--- a/src/components/code_block.jsx
+++ b/src/components/code_block.jsx
@@ -98,3 +98,13 @@ export function addOnClickHandleForLatexBlock(element) {
             }
         });
 }
+
+export function changeDirectionToColumnWhenLargerHeight() {
+    var msgBlocks = document.querySelectorAll('.mix-message__inner');
+    Array.from(msgBlocks).forEach(function (block) {
+        var height = block.offsetHeight;
+        if (height > 30) {
+            block.style.flexDirection = 'column';
+        }
+    });
+}

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -16,7 +16,8 @@ import {
     HighLightedCodeBlock,
     addOnClickHandleForCopyButton,
     renderInlineCodeBlockString,
-    addOnClickHandleForLatexBlock
+    addOnClickHandleForLatexBlock,
+    changeDirectionToColumnWhenLargerHeight
 } from './components/code_block';
 
 // States
@@ -165,6 +166,10 @@ function render() {
 
             // Handle click of Copy Latex Button
             addOnClickHandleForLatexBlock(markdownBody);
+
+            changeDirectionToColumnWhenLargerHeight();
+
+
 
             // 在外部浏览器打开连接
             markdownBody.querySelectorAll("a").forEach((e) => {

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -167,10 +167,6 @@ function render() {
             // Handle click of Copy Latex Button
             addOnClickHandleForLatexBlock(markdownBody);
 
-            changeDirectionToColumnWhenLargerHeight();
-
-
-
             // 在外部浏览器打开连接
             markdownBody.querySelectorAll("a").forEach((e) => {
                 e.classList.add("markdown_it_link");
@@ -190,7 +186,9 @@ function render() {
                 .forEach((elem) => {
                     posBase.before(elem)
                 })
-            messageBox.removeChild(posBase)
+            messageBox.removeChild(posBase);
+
+            changeDirectionToColumnWhenLargerHeight();
 
         })
 

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -168,6 +168,7 @@ pre.hl-code-block>button.lang_copy:not(:hover)>p.copy {
 /* 修复轻量工具箱等插件时间显示多出换行的问题 */
 .mix-message__inner {
     display: flex;
+    flex-direction: row;
 }
 
 .lite-tools-slot.embed-slot {


### PR DESCRIPTION
This is a workaround about the time slot issue when work with other plugins.

For me I still think these workarounds **is not good enough to be considered as the final solution**. Changing `div.mix-message__inner` display into flex and changing other style of this element may **higher the possibility of introducing other UI display issue when working with other plugins or even with QQNT updates in the future**.