### PR TITLE
fix: Fix link color issue in self-sent message.

### DIFF
--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -71,6 +71,12 @@ blockquote {
         text-decoration: underline;
     }
 
+    /* If the link is inside self-sent message, use white text */
+    /* Notice, this solution could work with LiteLoader theme (tested on Windows)*/
+    div.container--self a.markdown_it_link {
+        color: white;
+    }
+
     a.markdown_it_link:hover {
         color: #30a9de;
     }


### PR DESCRIPTION
我担心这么做可能会导致本来该显示蓝色连接的情况下显示为白色，可是目前测试之后，发现LiteTool和TG Theme都没有这个问题，应该是主题设置的样式会盖过`markdown.css`里面的设置。

毕竟用原来主题的人可能会比较多，所以我感觉这个确实有必要修，如果冲突了到时候就再revert吧（不过感觉只要是按照LiteLoader官方规范开发的主题，正确设定了自定义链接颜色的话，应该都没问题）